### PR TITLE
Add simulation script that puts response in json file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -452,3 +452,7 @@ $RECYCLE.BIN/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+
+## custom:
+temp/*

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Follow the guide below to setup and start the project.
 
 There are a few other commands that can be helpfull during testing or development.
 
-1. Cleanup kubernetes and helm char
+1. Cleanup kubernetes and helm charts
 
    If for any reason you want to clean up the configured kubernetes resources you can enter the following command in the terminal:
 

--- a/README.md
+++ b/README.md
@@ -113,3 +113,5 @@ There are a few other commands that can be helpfull during testing or developmen
    ```bash
    sh ./scripts/simulate_api_calls.sh
    ```
+
+   \* _In case of an error like 'jq command does not exist' [install jq](https://stedolan.github.io/jq/download/)_

--- a/README.md
+++ b/README.md
@@ -104,3 +104,12 @@ There are a few other commands that can be helpfull during testing or developmen
    ```bash
    sh ./scripts/docker/latest.deploy.sh
    ```
+
+3. Simulate API requests
+
+   In order to simulate API requests, you can use the script `simulate_api_calls.sh`. This script will by default call the api 500 times and save the responses to `temp/request_output.json`.
+   Use the script as follows:
+
+   ```bash
+   sh ./scripts/simulate_api_calls.sh
+   ```

--- a/scripts/simulate_api_calls.sh
+++ b/scripts/simulate_api_calls.sh
@@ -1,13 +1,15 @@
-function help {
+#!/bin/bash
+
+help() {
     echo "Use this script as follows:"
-    echo "  sh ./test.sh [options]\n"
+    echo "  sh path/to/simulate_api_calls.sh [options]\n"
     echo "Options are as follows:"
     echo "  -n: number -> number of times the api should be called.\n"
     echo "  -h: bool -> call for the help message.\n"
     exit {0}
 }
 
-function call {
+call() {
     curl --request POST -H "Content-Type:application/json" http://localhost/orders --data "{\"ItemIds\": [\"burger\", \"fries\"]}" --silent 
 }
 
@@ -45,11 +47,11 @@ done
 
 echo "API will be called $NO_CALLS times"
 
-
 COUNT=0
 
 echo "[" >> $RESPONSE_FILE
 
+# call api NO_CALLS times and append response to RESPONSE_FILE
 while test $COUNT -lt $NO_CALLS; do
     # function as defined above.
     output=$(call)

--- a/scripts/simulate_api_calls.sh
+++ b/scripts/simulate_api_calls.sh
@@ -12,16 +12,17 @@ function call {
 }
 
 NO_CALLS=1000
+RESPONSE_FILE="temp/request_output.json"
 
-if [ -f "file.json" ]; then
-   rm "file.json"
-   echo ""file.json" is removed"
+if [ -f $RESPONSE_FILE ]; then
+   rm $RESPONSE_FILE
+   echo "File: $RESPONSE_FILE is removed"
 fi
 
 
 echo "This is the script to call the prodtest api.\n"
 
-# generate help message
+# Check options
 while test $# -gt 0; do
     case $1 in
         -h|--help)
@@ -47,22 +48,19 @@ echo "API will be called $NO_CALLS times"
 
 COUNT=0
 
-echo "[" >> file.json
+echo "[" >> $RESPONSE_FILE
 
 while test $COUNT -lt $NO_CALLS; do
-    
-    # echo "\nCall number $COUNT:"
     # function as defined above.
     output=$(call)
-    # output=\'$output\'
-    # echo $output
-    echo "${output}" | jq >> file.json
+
+    echo "${output}" | jq >> $RESPONSE_FILE
     ((COUNT=COUNT+1))
     if test $COUNT -lt $NO_CALLS; then
-        echo "," >> file.json
+        echo "," >> $RESPONSE_FILE
     fi
 done
 
-echo "]" >> file.json
+echo "]" >> $RESPONSE_FILE
 
-echo "See file.json for results"
+echo "See '$RESPONSE_FILE' for results"

--- a/scripts/simulate_api_calls.sh
+++ b/scripts/simulate_api_calls.sh
@@ -1,0 +1,68 @@
+function help {
+    echo "Use this script as follows:"
+    echo "  sh ./test.sh [options]\n"
+    echo "Options are as follows:"
+    echo "  -n: number -> number of times the api should be called.\n"
+    echo "  -h: bool -> call for the help message.\n"
+    exit {0}
+}
+
+function call {
+    curl --request POST -H "Content-Type:application/json" http://localhost/orders --data "{\"ItemIds\": [\"burger\", \"fries\"]}" --silent 
+}
+
+NO_CALLS=1000
+
+if [ -f "file.json" ]; then
+   rm "file.json"
+   echo ""file.json" is removed"
+fi
+
+
+echo "This is the script to call the prodtest api.\n"
+
+# generate help message
+while test $# -gt 0; do
+    case $1 in
+        -h|--help)
+            help
+        ;;
+        -n)
+            shift
+            if test $# -gt 0; then
+                echo "the -n value is: $1"
+                NO_CALLS=$1
+            else
+                echo "No valid integer found after -n flag. Will use default (1000) as number of requests."
+            fi
+        ;;
+        *)
+            shift
+        ;;
+    esac
+done
+
+echo "API will be called $NO_CALLS times"
+
+
+COUNT=0
+
+echo "[" >> file.json
+
+while test $COUNT -lt $NO_CALLS; do
+    
+    # echo "\nCall number $COUNT:"
+    # function as defined above.
+    output=$(call)
+    # output=\'$output\'
+    # echo $output
+    echo "${output}" | jq >> file.json
+    ((COUNT=COUNT+1))
+    if test $COUNT -lt $NO_CALLS; then
+        echo "," >> file.json
+    fi
+done
+
+echo "]" >> file.json
+
+echo "See file.json for results"

--- a/scripts/simulate_api_calls.sh
+++ b/scripts/simulate_api_calls.sh
@@ -1,24 +1,32 @@
 #!/bin/bash
-
 help() {
     echo "Use this script as follows:"
     echo "  sh path/to/simulate_api_calls.sh [options]\n"
     echo "Options are as follows:"
     echo "  -n: number -> number of times the api should be called.\n"
     echo "  -h: bool -> call for the help message.\n"
-    exit {0}
+    exit 0
 }
 
 call() {
     curl --request POST -H "Content-Type:application/json" http://localhost/orders --data "{\"ItemIds\": [\"burger\", \"fries\"]}" --silent 
 }
 
-NO_CALLS=1000
-RESPONSE_FILE="temp/request_output.json"
+NO_CALLS=500
+RESPONSE_DIR="temp"
+RESPONSE_FILE="request_output.json"
+RESPONSE_FILE_PATH="$RESPONSE_DIR/$RESPONSE_FILE"
 
-if [ -f $RESPONSE_FILE ]; then
-   rm $RESPONSE_FILE
-   echo "File: $RESPONSE_FILE is removed"
+echo $RESPONSE_FILE_PATH
+
+if [ ! -d "$RESPONSE_DIR" ];
+then
+	mkdir $RESPONSE_DIR
+fi
+
+if [ -f $RESPONSE_FILE_PATH ]; then
+   rm $RESPONSE_FILE_PATH
+   echo "File: $RESPONSE_FILE_PATH is removed"
 fi
 
 
@@ -49,20 +57,21 @@ echo "API will be called $NO_CALLS times"
 
 COUNT=0
 
-echo "[" >> $RESPONSE_FILE
+echo "[" >> $RESPONSE_FILE_PATH
 
 # call api NO_CALLS times and append response to RESPONSE_FILE
 while test $COUNT -lt $NO_CALLS; do
     # function as defined above.
     output=$(call)
 
-    echo "${output}" | jq >> $RESPONSE_FILE
-    ((COUNT=COUNT+1))
+    echo "${output}" | jq >> $RESPONSE_FILE_PATH
+    COUNT=$((COUNT+1))
+
     if test $COUNT -lt $NO_CALLS; then
-        echo "," >> $RESPONSE_FILE
+        echo "," >> $RESPONSE_FILE_PATH
     fi
 done
 
-echo "]" >> $RESPONSE_FILE
+echo "]" >> $RESPONSE_FILE_PATH
 
-echo "See '$RESPONSE_FILE' for results"
+echo "See '$RESPONSE_FILE_PATH' for results"


### PR DESCRIPTION
Contains:
- Bash script that calls the api 500 times by default (configurable)
- outputs all responses to `temp/request_output.json`
- updated readme with new script

resolves #3 